### PR TITLE
Add sweep mode for smooth continuously-changing colours

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,3 +66,15 @@ body {
 .more a {
   color: white;
 }
+
+input[type="radio"] {
+    display: none;
+}
+
+label {
+    opacity: 0.5;
+}
+
+input:checked + label {
+    opacity: 1;
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
   <div class="clock">
     <div id="date"></div>
     <div id="time"></div>
+    <div id="mode">
+      <input type="radio" name="mode" id="tick" checked onClick="setSweep(false);" /><label for="tick">Tick</label>
+      <input type="radio" name="mode" id="sweep" onClick="setSweep(true);" /><label for="sweep">Sweep</label>
+    </div>
   </div>
 
   <div class="more">

--- a/js/script.js
+++ b/js/script.js
@@ -7,6 +7,8 @@ const secondsElement = document.getElementById('seconds');
 const dateElement = document.getElementById('date');
 const timeElement = document.getElementById('time');
 
+var sweep = false;
+
 function updateDateTime() {
 
   let date = new Date();
@@ -20,10 +22,21 @@ function updateDateTime() {
   let hours = date.getHours();
   let minutes = date.getMinutes();
   let seconds = date.getSeconds();
+  
+  let monthDays = daysInMonth(date);
+  
+  if (sweep) {
+    seconds += date.getMilliseconds() / 1000;
+    minutes += seconds / 60;
+    hours += minutes / 60;
+    days += hours / 24;
+    months += days / monthDays;
+    years += months / 12;
+  }
 
   let yearsColour = getColour(years.toString().substring(2) / 100);
   let monthsColour = getColour(months / 12);
-  let daysColour = getColour(days / daysInMonth(date));
+  let daysColour = getColour(days / monthDays);
   let hoursColour = getColour(hours / 24);
   let minutesColour = getColour(minutes / 60);
   let secondsColour = getColour(seconds / 60);
@@ -34,7 +47,12 @@ function updateDateTime() {
   hoursElement.style.backgroundImage = `linear-gradient(170deg, ${hoursColour} , ${minutesColour})`;
   minutesElement.style.backgroundImage = `linear-gradient(170deg, ${minutesColour} , ${secondsColour})`;
   secondsElement.style.backgroundImage = `linear-gradient(170deg, ${secondsColour} , ${yearsColour})`;
-
+  
+  if (sweep) {
+    setTimeout(updateDateTime, 100);
+  } else {
+    setTimeout(updateDateTime, 1000);
+  }
 }
 
 function getColour(percentage) {
@@ -75,8 +93,8 @@ function daysInMonth(date) {
   return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
 }
 
-updateDateTime();
+function setSweep(newSweep) {
+    sweep = newSweep;
+}
 
-setInterval(() => {
-  updateDateTime();
-}, 1000);
+updateDateTime();


### PR DESCRIPTION
I added a switch to choose between the existing ticking mode and a new mode that takes the same approach as a sweep second hand on an analogue clock. Instead of suddenly changing when the number changes, each colour slowly progresses smoothly based on how far through the current hour/minute/etc it is. There is a switch in the UI to choose which mode you prefer.